### PR TITLE
PHP 7.2 Error Fix

### DIFF
--- a/src/DreamCommerce/ShopAppstoreLib/Resource.php
+++ b/src/DreamCommerce/ShopAppstoreLib/Resource.php
@@ -372,7 +372,7 @@ class Resource
      */
     protected function isCollection($args)
     {
-        return !$this->isSingleOnly && count($args)==0;
+        return !$this->isSingleOnly && empty($args);
     }
 
     /**


### PR DESCRIPTION
PHP 7.2: count(): Parameter must be an array or an object that implements Countable