### PR TITLE
Set the page to a minimum of 1 in resource.

### DIFF
--- a/src/DreamCommerce/ShopAppstoreLib/Resource.php
+++ b/src/DreamCommerce/ShopAppstoreLib/Resource.php
@@ -260,7 +260,7 @@ class Resource
     {
         $page = (int)$page;
 
-        if($page<0){
+        if($page<1){
             throw new \RuntimeException('Invalid page specified', ResourceException::INVALID_PAGE);
         }
 


### PR DESCRIPTION
Why ?
---

- Setting page to 0 causes that api returns first page of results two times - on zero page nad first page
- Setting page to 1 sounds better than set page to "0" page

